### PR TITLE
Enabling the use of time in alert templates

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,7 +83,9 @@ func getWebRouter() http.Handler {
 }
 
 // defaultFuncs is copied from alertmanager templates
+// adding "now" to allow for injection of time into alert
 var defaultFuncs = template.FuncMap{
+	"now":     time.Now,
 	"toUpper": strings.ToUpper,
 	"toLower": strings.ToLower,
 	"title":   strings.Title,


### PR DESCRIPTION
This small change enables the use of `now` in the alert template. This is specifically useful for adding a time element to outgoing dashboard or informational links.

It enables templates similar to this:
```
...
Source: <{{ $.Annotations.grafanaDashboard }}?from={{ now.Unix }}-30m&to={{ now.Unix }}|view dashboard>
```