### PR TITLE
Adding helper functions for time templating

### DIFF
--- a/main.go
+++ b/main.go
@@ -83,12 +83,24 @@ func getWebRouter() http.Handler {
 }
 
 // defaultFuncs is copied from alertmanager templates
-// adding "now" to allow for injection of time into alert
+// Additionally added now, hour and minute for time templating
 var defaultFuncs = template.FuncMap{
-	"now":     time.Now,
 	"toUpper": strings.ToUpper,
 	"toLower": strings.ToLower,
 	"title":   strings.Title,
+	"now":     time.Now,
+	// Usage example for grafana timestamps representing 1hr ago:
+	// {{ (now.Add (hour -1)).Unix }}000
+	"hour": func(h int32) time.Duration {
+		timeString := fmt.Sprintf("%dh",h)
+		duration,_ := time.ParseDuration(timeString)
+		return duration
+	},
+	"minute": func(m int32) time.Duration {
+		timeString := fmt.Sprintf("%dm",m)
+		duration,_ := time.ParseDuration(timeString)
+		return duration
+	},
 	// join is equal to strings.Join but inverts the argument order
 	// for easier pipelining in templates.
 	"join": func(sep string, s []string) string {


### PR DESCRIPTION
This is related to the other time-related PR: https://github.com/FortnoxAB/alertmanager2hangoutschat/pull/6

This adds two helper functions (hour and minute) to make it easier to template times.

Allowing for something like:
```
...
Source: <{{ $.Annotations.grafanaDashboard }}?from={{ (now.Add (hour -1)).Unix }}000&to={{ now.Unix }}000|view dashboard>
```

For the previous iteration I was under the assumption that `?from={{ now.Unix }}-30m` would work, but it turns out that relative times are not supported with timestamps. Also the `000` is important specifically for grafana as it expects milliseconds and not seconds.